### PR TITLE
Moved angular-mocks dependency to dev dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,10 @@
     "angular": "1.2 - 2",
     "angular-resource": "1.2 - 2",
     "angular-route": "1.2 - 2",
-	"angular-mocks": "1.2 - 2",
     "angular-scenario": "1.2 - 2"
   },
   "devDependencies": {
-    "sinon-1.11.1": "http://sinonjs.org/releases/sinon-1.11.1.js"
+    "sinon-1.11.1": "http://sinonjs.org/releases/sinon-1.11.1.js",
+	"angular-mocks": "1.2 - 2"
   }
 }


### PR DESCRIPTION
Having angular-mocks as a dependency was causing it to get injected into index.html which resulted in multiple references of it in karma.
